### PR TITLE
Don't modify items array passed to QuickScore constructor

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -138,6 +138,7 @@ module.exports = {
 		"no-extra-label": "error",
 		"no-extra-parens": "off",
 		"no-floating-decimal": "off",
+		"no-global-assign": "error",
 		"no-implicit-coercion": "error",
 		"no-implicit-globals": "error",
 		"no-implied-eval": "error",


### PR DESCRIPTION
Return original item on a .item key in the results.
Have a separate loop for the case of a flat array of strings.
setItems() becomes trivial.
Add tests for empty query returning 0 scores, items array doesn't get modified.
Add no-global-assign to eslintrc.
Move eslint override to line that needs it in QuickScore.js.
